### PR TITLE
Small Fixes To Dm: Toolbar

### DIFF
--- a/src/components/Common/Button/Button.js
+++ b/src/components/Common/Button/Button.js
@@ -72,9 +72,9 @@ export const Button = React.forwardRef(
 );
 Button.displayName = "Button";
 
-Button.Group = ({ className, children, collapsed }) => {
+Button.Group = ({ className, children, collapsed, ...rest }) => {
   return (
-    <Block name="button-group" mod={{ collapsed }} mix={className}>
+    <Block name="button-group" mod={{ collapsed }} mix={className} {...rest}>
       {children}
     </Block>
   );

--- a/src/components/Common/FiltersPane.js
+++ b/src/components/Common/FiltersPane.js
@@ -1,6 +1,6 @@
 import { inject, observer } from "mobx-react";
 import React, { useEffect, useRef } from "react";
-import { FaAngleDown, FaFilter } from "react-icons/fa";
+import { FaAngleDown } from "react-icons/fa";
 import { Filters } from "../Filters/Filters";
 import { Badge } from "./Badge/Badge";
 import { Button } from "./Button/Button";
@@ -24,7 +24,6 @@ export const FiltersButton = buttonInjector(observer(
       <Button
         ref={ref}
         size={size}
-        icon={<FaFilter />}
         onClick={() => sidebarEnabled && viewsStore.toggleSidebar()}
         {...rest}
       >

--- a/src/components/Common/RadioGroup/RadioGroup.js
+++ b/src/components/Common/RadioGroup/RadioGroup.js
@@ -4,7 +4,7 @@ import "./RadioGroup.styl";
 
 const RadioContext = React.createContext();
 
-export const RadioGroup = ({ size, value, onChange, children }) => {
+export const RadioGroup = ({ size, value, onChange, children, ...rest }) => {
   const onRadioChange = (e) => {
     onChange?.(e);
   };
@@ -16,7 +16,7 @@ export const RadioGroup = ({ size, value, onChange, children }) => {
         onChange: onRadioChange,
       }}
     >
-      <div className={cn("radio-group").mod({ size })}>
+      <div className={cn("radio-group").mod({ size })} {...rest}>
         <div className={cn("radio-group").elem("buttons")}>{children}</div>
       </div>
     </RadioContext.Provider>

--- a/src/components/DataManager/Toolbar/ActionsButton.js
+++ b/src/components/DataManager/Toolbar/ActionsButton.js
@@ -10,7 +10,7 @@ const injector = inject(({ store }) => ({
   hasSelected: store.currentView?.selected?.hasSelected ?? false,
 }));
 
-export const ActionsButton = injector(observer(({ store, size, hasSelected }) => {
+export const ActionsButton = injector(observer(({ store, size, hasSelected, ...rest }) => {
   const selectedCount = store.currentView.selectedCount;
   const actions = store.availableActions
     .filter((a) => !a.hidden)
@@ -54,7 +54,7 @@ export const ActionsButton = injector(observer(({ store, size, hasSelected }) =>
 
   return (
     <Dropdown.Trigger content={<Menu size="compact">{actionButtons}</Menu>} disabled={!hasSelected}>
-      <Button size={size} disabled={!hasSelected}>
+      <Button size={size} disabled={!hasSelected} {...rest} >
         {selectedCount > 0 && selectedCount} Tasks
         <FaAngleDown size="16" style={{ marginLeft: 4 }} color="#0077FF" />
       </Button>

--- a/src/components/DataManager/Toolbar/OrderButton.js
+++ b/src/components/DataManager/Toolbar/OrderButton.js
@@ -13,14 +13,14 @@ const injector = inject(({ store }) => {
   };
 });
 
-export const OrderButton = injector(({ size, ordering, view }) => {
+export const OrderButton = injector(({ size, ordering, view, ...rest }) => {
   return (
     <Space style={{ fontSize: 12 }}>
       Order
-      <Button.Group collapsed>
+      <Button.Group collapsed {...rest} >
         <FieldsButton
           size={size}
-          style={{ minWidth: 85, textAlign: "left" }}
+          style={{ minWidth: 67, textAlign: "left", marginRight: -1 }}
           title={ordering ? ordering.column?.title : "not set"}
           onClick={(col) => view.setOrdering(col.id)}
           onReset={() => view.setOrdering(null)}

--- a/src/components/DataManager/Toolbar/RefreshButton.js
+++ b/src/components/DataManager/Toolbar/RefreshButton.js
@@ -10,7 +10,7 @@ const injector = inject(({ store }) => {
   };
 });
 
-export const RefreshButton = injector(({ store, needsDataFetch, projectFetch, size }) => {
+export const RefreshButton = injector(({ store, needsDataFetch, projectFetch, size, ...rest }) => {
   return (
     <Space size={size}>
       <Button
@@ -21,7 +21,12 @@ export const RefreshButton = injector(({ store, needsDataFetch, projectFetch, si
           await store.fetchProject({ force: true, interaction: 'refresh' });
           await store.currentView?.reload();
         }}
-      >Refresh</Button>
+        {...rest}
+      >
+        <span style={{ textAlign: 'center', width: '100%' }}>
+          Refresh
+        </span>
+      </Button>
       {needsDataFetch && "Update available"}
     </Space>
   );

--- a/src/components/DataManager/Toolbar/ViewToggle.js
+++ b/src/components/DataManager/Toolbar/ViewToggle.js
@@ -6,35 +6,35 @@ const viewInjector = inject(({ store }) => ({
   view: store.currentView,
 }));
 
-export const ViewToggle = viewInjector(observer(({ view, size }) => {
+export const ViewToggle = viewInjector(observer(({ view, size, ...rest }) => {
   return (
-    <>
-      <RadioGroup
-        size={size}
-        value={view.type}
-        onChange={(e) => view.setType(e.target.value)}
-      >
-        <RadioGroup.Button value="list">
-          <Tooltip title="List view">
-            <span>List</span>
-          </Tooltip>
-        </RadioGroup.Button>
-        <RadioGroup.Button value="grid">
-          <Tooltip title="Grid view">
-            <span>Grid</span>
-          </Tooltip>
-        </RadioGroup.Button>
-      </RadioGroup>
-    </>
+    <RadioGroup
+      size={size}
+      value={view.type}
+      onChange={(e) => view.setType(e.target.value)}
+      {...rest}
+    >
+      <RadioGroup.Button value="list">
+        <Tooltip title="List view">
+          <span>List</span>
+        </Tooltip>
+      </RadioGroup.Button>
+      <RadioGroup.Button value="grid">
+        <Tooltip title="Grid view">
+          <span>Grid</span>
+        </Tooltip>
+      </RadioGroup.Button>
+    </RadioGroup>
   );
 }));
 
-export const DataStoreToggle = viewInjector(({ view, size }) => {
+export const DataStoreToggle = viewInjector(({ view, size, ...rest }) => {
   return (
     <RadioGroup
       value={view.target}
       size={size}
       onChange={(e) => view.setTarget(e.target.value)}
+      {...rest}
     >
       <RadioGroup.Button value="tasks">
         Tasks

--- a/src/components/DataManager/Toolbar/instruments.js
+++ b/src/components/DataManager/Toolbar/instruments.js
@@ -1,4 +1,4 @@
-import { FaCaretDown, FaColumns } from "react-icons/fa";
+import { FaCaretDown } from "react-icons/fa";
 import { ErrorBox } from "../../Common/ErrorBox";
 import { FieldsButton } from "../../Common/FieldsButton";
 import { FiltersPane } from "../../Common/FiltersPane";
@@ -13,32 +13,34 @@ import { OrderButton } from "./OrderButton";
 import { RefreshButton } from "./RefreshButton";
 import { ViewToggle } from "./ViewToggle";
 
+const style = { minWidth: '110px', justifyContent: 'space-between' };
+
 export const instruments = {
   'view-toggle': ({ size }) => {
-    return <ViewToggle size={size} />;
+    return <ViewToggle size={size} style={style} />;
   },
   'columns': ({ size }) => {
     return (
       <FieldsButton
         wrapper={FieldsButton.Checkbox}
-        icon={<Icon icon={FaColumns} />}
         trailingIcon={<Icon icon={FaCaretDown} />}
-        title={"Fields"}
+        title={"Columns"}
         size={size}
+        style={style}
       />
     );
   },
   'filters': ({ size }) => {
-    return <FiltersPane size={size} />;
+    return <FiltersPane size={size} style={style} />;
   },
   'ordering': ({ size }) => {
-    return <OrderButton size={size} />;
+    return <OrderButton size={size} style={style} />;
   },
   'grid-size': ({ size }) => {
     return <GridWidthButton size={size}/>;
   },
   'refresh': ({ size }) => {
-    return <RefreshButton size={size}/>;
+    return <RefreshButton size={size} style={style}/>;
   },
   'loading-possum': () => {
     return <LoadingPossum/>;
@@ -47,7 +49,7 @@ export const instruments = {
     return <LabelButton size={size}/>;
   },
   'actions': ({ size }) => {
-    return <ActionsButton size={size}/>;
+    return <ActionsButton size={size} style={style} />;
   },
   'error-box': () => {
     return <ErrorBox/>;


### PR DESCRIPTION
[ext] There should always be “Tasks” button in toolbar. If no tasks are selected, it should be disabled but visible anyway
[ext] The min-width of “Tasks” button should fit at least 3 digits if it says ”N Tasks” (110px), when more digits it should resize
[ext] Both List/Grid radiogroup and Refresh button should be the same width of 110px (in other words, the same width of Tasks button)[ext] Thinner and more transparent Plus icon with rgba(0,0,0,.15) static, and rgba(0,0,0,.35) hover states
[ext] Make stats at the very right more dimmer with rgba(0,0,0,.3) text color
