### PR TITLE
[fix] Fix crash when audio duration is Infinity

### DIFF
--- a/src/components/Common/AudioPlayer/Duration.js
+++ b/src/components/Common/AudioPlayer/Duration.js
@@ -1,4 +1,7 @@
 export const Duration = ({ value, format }) => {
+  if (value === Infinity) {
+    return 'Infinity';
+  }
   const formatted = new Date(value * 1000).toISOString().substr(11, 8);
 
   const parsed = formatted.split(':');

--- a/src/components/Common/AudioPlayer/Duration.js
+++ b/src/components/Common/AudioPlayer/Duration.js
@@ -1,6 +1,6 @@
 export const Duration = ({ value, format }) => {
   if (value === Infinity) {
-    return 'Infinity';
+    return 'Unknown';
   }
   const formatted = new Date(value * 1000).toISOString().substr(11, 8);
 


### PR DESCRIPTION
This can happen because of a bug in the browser, or if the server serving the audio file doesn't support range requests.