### PR TITLE
Release 2.2.0 (DEV-2098)

### DIFF
--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -591,7 +591,8 @@ export class LSFWrapper {
       !annotation.userGenerate || annotation.sentUserGenerate;
 
     const result = {
-      lead_time: (new Date() - annotation.loadedDate) / 1000, // task execution time
+      // task execution time, always summed up with previous values
+      lead_time: (new Date() - annotation.loadedDate) / 1000 + Number(annotation.leadTime ?? 0),
       // don't serialize annotations twice for drafts
       result: draft ? annotation.versions.draft : annotation.serializeAnnotation(),
       draft_id: annotation.draftId,


### PR DESCRIPTION
- fix: DEV-2098: sum lead_time for different runs (#42)