### PR TITLE
feat: DEV-2715: Audio v3 improvements (#133)

### DIFF
--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -11,7 +11,7 @@
  * interfacesModifier: function,
  * }} LSFOptions */
 
-import { FF_DEV_1752, FF_DEV_2186, FF_DEV_2887, FF_DEV_3034, isFF } from "../utils/feature-flags";
+import { FF_DEV_1752, FF_DEV_2186, FF_DEV_2715, FF_DEV_2887, FF_DEV_3034, isFF } from "../utils/feature-flags";
 import { isDefined } from "../utils/utils";
 import { Modal } from "../components/Common/Modal/Modal";
 import { CommentsSdk } from "./comments-sdk";
@@ -148,6 +148,8 @@ export class LSFWrapper {
     console.groupEnd();
 
     const lsfProperties = {
+      // ensure that we are able to distinguish at component level if the app has fully hydrated.
+      hydrated: false,
       user: options.user,
       config: this.lsfConfig,
       task: taskToLSFormat(this.task),
@@ -341,6 +343,13 @@ export class LSFWrapper {
     this.lsf.initializeStore(lsfTask);
     this.setAnnotation(annotationID, fromHistory || isRejectedQueue);
     this.setLoading(false);
+    if (isFF(FF_DEV_2715)) {
+      this.setHydrated(true);
+    }
+  }
+
+  setHydrated(value) {
+    this.lsf.setHydrated?.(value);
   }
 
   /** @private */

--- a/src/utils/feature-flags.js
+++ b/src/utils/feature-flags.js
@@ -23,6 +23,12 @@ export const FF_DEV_1752 = "feat_front_dev_1752_notification_links_in_label_and_
 // toggles the ability to drag columns on the datamanager table
 export const FF_DEV_2984 = "fflag_feat_front_dev_2984_dm_draggable_columns_short";
 
+/**
+ * Support for loading media files only a single time. Part of the Audio v3 epic.
+ * @link https://app.launchdarkly.com/default/production/features/ff_front_dev_2715_audio_3_280722_short
+ */
+export const FF_DEV_2715 = 'ff_front_dev_2715_audio_3_280722_short';
+
 // Customize flags
 const flags = {};
 


### PR DESCRIPTION
* feat: DEV-2715: Audio v3 improvements

* initialize hydrated state to false, so the default in LSF remains true

* only setHydrated with FF set

* fix: DEV-3917: Reinit history after draft applied (#136)

Co-authored-by: hlomzik <hlomzik@gmail.com>
Co-authored-by: Nick Skriabin <767890+nicholasrq@users.noreply.github.com>