### PR TITLE
feat: LSDV-3936: Task history is stored on the backend

### DIFF
--- a/src/sdk/api-config.js
+++ b/src/sdk/api-config.js
@@ -47,6 +47,9 @@ export const APIConfig = {
     /** List of tasks (samples) in the dataset */
     tasks: "/tasks",
 
+    /** List of task history */
+    taskHistory: "/../projects/:projectId/label-stream-history",
+
     /** Per-task annotations (annotations, predictions) */
     annotations: "/views/:tabID/annotations",
 

--- a/src/sdk/lsf-sdk.js
+++ b/src/sdk/lsf-sdk.js
@@ -347,7 +347,7 @@ export class LSFWrapper {
     // undefined or true for backward compatibility
     this.lsf.toggleInterface("postpone", this.task.allow_postpone !== false);
     this.lsf.toggleInterface("topbar:task-counter", !isFF(FF_DEV_3734));
-    this.lsf.assignTask(task, taskHistory);
+    this.lsf.assignTask(task);
     this.lsf.initializeStore(lsfTask);
     this.setAnnotation(annotationID, fromHistory || isRejectedQueue);
     this.setLoading(false);
@@ -496,6 +496,12 @@ export class LSFWrapper {
     this.lsf = ls;
 
     if (!this.lsf.task) this.setLoading(true);
+
+    const _taskHistory =  await this.datamanager.store.taskStore.loadTaskHistory({
+      projectId: this.datamanager.store.project.id,
+    });
+
+    this.lsf.setTaskHistory(_taskHistory);
 
     await this.loadUserLabels();
 

--- a/src/stores/DataStores/tasks.js
+++ b/src/stores/DataStores/tasks.js
@@ -101,6 +101,18 @@ export const create = (columns) => {
     },
   })
     .actions((self) => ({
+      loadTaskHistory: flow(function* (props) {
+        let taskHistory = yield self.root.apiCall("taskHistory", props);
+
+        taskHistory = taskHistory.map((task) => {
+          return {
+            taskId: task.taskId,
+            annotationId: task.annotationId?.toString(),
+          };
+        });
+
+        return taskHistory;
+      }),
       loadTask: flow(function* (taskID, { select = true } = {}) {
         if (!isDefined(taskID)) {
           console.warn("Task ID must be provided");


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Task history now is stored on the backend, now you can navigate through the tasks stored on the backend on label stream clicking on the arrows.


#### What is the new behavior?
Now the task history is stored on the backend for label stream



#### What is the current behavior?
Task history is not stored in any place, so if you navigating through the tasks and refresh the browser you lose the task history.



#### What libraries were added/updated?
NA



#### Does this change affect performance?
No



#### Does this change affect security?
No



#### What alternative approaches were there?
NA



#### What feature flags were used to cover this change?
NA



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit
