### PR TITLE
fix: LSDV-4746-1: Only include limited fields for project when polling

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -422,10 +422,19 @@ export const AppStore = types
       self.projectFetch = options.force === true;
 
       const oldProject = JSON.stringify(self.project ?? {});
+      const isTimer = options.interaction === "timer";
       const params =
         options && options.interaction
           ? {
             interaction: options.interaction,
+            ...(isTimer ? ({
+              include: [
+                "task_count",
+                "task_number",
+                "annotation_count",
+                "num_tasks_with_annotations",
+              ].join(","),
+            }) : null),
           }
           : null;
 
@@ -440,7 +449,9 @@ export const AppStore = types
           self.project.num_tasks_with_annotations !== newProject.num_tasks_with_annotations
         ) : false;
 
-        if (JSON.stringify(newProject ?? {}) !== oldProject) {
+        if (options.interactiom === "timer") {
+          self.project = Object.assign(oldProject, newProject);
+        } else if (JSON.stringify(newProject ?? {}) !== oldProject) {
           self.project = newProject;
         }
       } catch {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change

There are performance issues when requesting too many fields in the datamanager for a given project.



#### What does this fix?

Reduces fields included in the results for project queries fired from polling.



#### Does this change affect performance?

This should increase performance given the requests will not have to process certain problematic fields, which were also going unneeded. 



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Project TaskList

