### PR TITLE
fix: LSDV-4711: CORS error accessing previously annotated data

### DIFF
--- a/src/components/CellViews/ImageCell.js
+++ b/src/components/CellViews/ImageCell.js
@@ -1,5 +1,10 @@
 import { getRoot } from "mobx-state-tree";
+import { FF_LSDV_4711, isFF } from "../../utils/feature-flags";
 import { AnnotationPreview } from "../Common/AnnotationPreview/AnnotationPreview";
+
+const imgDefaultProps = {};
+
+if (isFF(FF_LSDV_4711)) imgDefaultProps.crossOrigin = 'anonymous';
 
 export const ImageCell = (column) => {
   const {
@@ -16,7 +21,7 @@ export const ImageCell = (column) => {
 
   return renderImagePreview ? (
     <img
-      crossOrigin="anonymous"
+      {...imgDefaultProps}
       key={imgSrc}
       src={imgSrc}
       alt="Data"

--- a/src/components/CellViews/ImageCell.js
+++ b/src/components/CellViews/ImageCell.js
@@ -16,6 +16,7 @@ export const ImageCell = (column) => {
 
   return renderImagePreview ? (
     <img
+      crossOrigin="anonymous"
       key={imgSrc}
       src={imgSrc}
       alt="Data"

--- a/src/components/Common/AnnotationPreview/AnnotationPreview.js
+++ b/src/components/Common/AnnotationPreview/AnnotationPreview.js
@@ -123,6 +123,7 @@ export const AnnotationPreview = injector(
 
     return preview ? (
       <img
+        crossOrigin="anonymous"
         src={preview[`$${name}`][variant]}
         alt=""
         style={style}

--- a/src/components/Common/AnnotationPreview/AnnotationPreview.js
+++ b/src/components/Common/AnnotationPreview/AnnotationPreview.js
@@ -2,8 +2,13 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 import { taskToLSFormat } from "../../../sdk/lsf-utils";
 import { Block } from "../../../utils/bem";
+import { FF_LSDV_4711, isFF } from "../../../utils/feature-flags";
 import { Spinner } from "../Spinner";
 import "./AnnotationPreview.styl";
+
+const imgDefaultProps = {};
+
+if (isFF(FF_LSDV_4711)) imgDefaultProps.crossOrigin = 'anonymous';
 
 const wait = (timeout) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
@@ -123,7 +128,7 @@ export const AnnotationPreview = injector(
 
     return preview ? (
       <img
-        crossOrigin="anonymous"
+        {...imgDefaultProps}
         src={preview[`$${name}`][variant]}
         alt=""
         style={style}

--- a/src/components/Common/MediaPlayer/MediaPlayer.js
+++ b/src/components/Common/MediaPlayer/MediaPlayer.js
@@ -173,7 +173,7 @@ export const MediaPlayer = ({ src, video = false }) => {
 
 const MediaSource = forwardRef(({ type = "audio", src, ...props }, ref) => {
   return (
-    <Elem name="media" tag={type} ref={ref} {...props}>
+    <Elem crossOrigin="anonymous" name="media" tag={type} ref={ref} {...props}>
       <source src={src}/>
     </Elem>
   );

--- a/src/components/Common/MediaPlayer/MediaPlayer.js
+++ b/src/components/Common/MediaPlayer/MediaPlayer.js
@@ -8,6 +8,12 @@ import "./MediaPlayer.styl";
 import { MediaSeeker } from "./MediaSeeker";
 import { Duration } from "./Duration";
 import { forwardRef } from "react";
+import { FF_LSDV_4711, isFF } from "../../../utils/feature-flags";
+
+
+const mediaDefaultProps = {};
+
+if (isFF(FF_LSDV_4711)) mediaDefaultProps.crossOrigin = 'anonymous';
 
 const initialState = {
   duration: 0,
@@ -173,7 +179,7 @@ export const MediaPlayer = ({ src, video = false }) => {
 
 const MediaSource = forwardRef(({ type = "audio", src, ...props }, ref) => {
   return (
-    <Elem crossOrigin="anonymous" name="media" tag={type} ref={ref} {...props}>
+    <Elem {...mediaDefaultProps} name="media" tag={type} ref={ref} {...props}>
       <source src={src}/>
     </Elem>
   );

--- a/src/utils/feature-flags.js
+++ b/src/utils/feature-flags.js
@@ -52,6 +52,11 @@ export const FF_LOPS_12 = "fflag_feat_front_lops_12_label_ops_ui_short";
  */
 export const FF_LOPS_E_3 = "fflag_feat_all_lops_e_3_datasets_short";
 
+/**
+ * Fixes how presigned urls are generated and accessed to remove possibility of CORS errors.
+ */
+export const FF_LSDV_4711 = 'fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short';
+
 // Customize flags
 const flags = {};
 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
There are intermittent CORS errors generated when accessing media elements with presigned urls, prior to making fetch or xhr GET requests for the contents.



#### What does this fix?
Sets `crossOrigin="anonymous"` on any media type tags (img,audio,video) so that servers which utilize presigned urls (ie. cloud storage) will properly send back the appropriate `Access-Control-Allow-` headers. Without these headers present, all further requests made to the presigned url will fail with CORS errors.



#### What feature flags were used to cover this change?
- `fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short`


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
AnnotationPreview,MediaPlayer
