### PR TITLE
fix: LSDV-5008: Make DM default width equal to the main menu width in Quick View

### DIFF
--- a/src/stores/Tabs/tab.js
+++ b/src/stores/Tabs/tab.js
@@ -51,9 +51,10 @@ export const Tab = types
     deletable: true,
   })
   .volatile(() => {
-    const defaultWidth = window.innerWidth * 0.35;
+    const defaultWidth = getComputedStyle(document.body).getPropertyValue("--menu-sidebar-width").replace("px", "").trim();
+
     const labelingTableWidth = parseInt(
-      localStorage.getItem("labelingTableWidth") ?? defaultWidth,
+      localStorage.getItem("labelingTableWidth") ?? defaultWidth ?? 200,
     );
 
     return {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product design
- [X] Frontend



### Describe the reason for change
The defaultWidth of the DataManager Table view when QuickView is loaded was not the correct size.



#### What does this fix?
Use the css custom property of the exact menu sidebar width to set the default width of the Quickview viewable Datamanager sidebar.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)


### Which logical domain(s) does this change affect?
QuickView

