### PR TITLE
fix: LSDV-5177:Fix draft loss on switching tasks in quick view mode

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -1,6 +1,6 @@
 import { destroy, flow, types } from "mobx-state-tree";
 import { Modal } from "../components/Common/Modal/Modal";
-import { FF_DEV_2887, isFF } from "../utils/feature-flags";
+import { FF_DEV_2887, FF_LSDV_5177, isFF } from "../utils/feature-flags";
 import { History } from "../utils/history";
 import { isDefined } from "../utils/utils";
 import { Action } from "./Action";
@@ -322,6 +322,10 @@ export const AppStore = types
           self.closeLabeling();
         }
       };
+
+      if (isFF(FF_LSDV_5177)) {
+        self.LSF?.lsf?.annotationStore?.selected?.saveDraftImmediately?.();
+      }
 
       if (isFF(FF_DEV_2887) && self.LSF?.lsf?.annotationStore?.selected?.commentStore?.hasUnsaved) {
         Modal.confirm({

--- a/src/utils/feature-flags.js
+++ b/src/utils/feature-flags.js
@@ -59,6 +59,11 @@ export const FF_LOPS_E_3 = "fflag_feat_all_lops_e_3_datasets_short";
  */
 export const FF_LSDV_4711 = 'fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short';
 
+/**
+ * Add forced draft saving on switching between different tasks in Quick View.
+ */
+export const FF_LSDV_5177 = 'fflag_fix_front_lsdv_5177_save_draft_on_task_switch_250523_short';
+
 // Customize flags
 const flags = {};
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Drafts are not saved every time you switch between tasks in Quick View mode.


#### What feature flags were used to cover this change?
`fflag_fix_front_lsdv_5177_save_draft_on_task_switch_250523_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Datamanager`, `QuickView`, `Drafts`, `autosave`

