### PR TITLE
feat: LSDV-5035: Use created_at from draft as the annotation draft_created_at

### DIFF
--- a/src/sdk/lsf-utils.ts
+++ b/src/sdk/lsf-utils.ts
@@ -1,4 +1,11 @@
-import { APIAnnotation, APIPrediction, APITask, LSFAnnotation, LSFTaskData } from "../types/Task";
+import {
+  APIAnnotation,
+  APIPrediction,
+  APITask,
+  LSFAnnotation,
+  LSFTaskData
+} from "../types/Task";
+import { FF_LSDV_5035, isFF } from "../utils/feature-flags";
 
 /**
  * Converts the task from the server format to the
@@ -29,13 +36,17 @@ export const taskToLSFormat = (task: APITask): LSFTaskData | void => {
 };
 
 export const annotationToLSF = (annotation: APIAnnotation) => {
+  const createdDate = isFF(FF_LSDV_5035)
+    ? annotation.draft_created_at || annotation.created_at
+    : annotation.created_at;
+
   return {
     ...annotation,
     id: undefined,
     pk: String(annotation.id),
     createdAgo: annotation.created_ago,
     createdBy: annotation.created_username,
-    createdDate: annotation.created_at,
+    createdDate,
     leadTime: annotation.lead_time ?? 0,
     skipped: annotation.was_cancelled ?? false,
   };
@@ -52,7 +63,9 @@ export const predictionToLSF = (prediction: APIPrediction) => {
   };
 };
 
-export const annotationToServer = (annotation: LSFAnnotation): APIAnnotation => {
+export const annotationToServer = (
+  annotation: LSFAnnotation,
+): APIAnnotation => {
   return {
     ...annotation,
     id: Number(annotation.pk),

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -13,6 +13,7 @@ export interface APIAnnotation {
 
   created_at: DateTime;
   updated_at?: DateTime;
+  draft_created_at?: DateTime;
 
   /** How much time it took to annotate the task */
   lead_time?: number | null;

--- a/src/utils/feature-flags.js
+++ b/src/utils/feature-flags.js
@@ -59,6 +59,11 @@ export const FF_LOPS_E_3 = "fflag_feat_all_lops_e_3_datasets_short";
  */
 export const FF_LSDV_4711 = 'fflag_fix_all_lsdv_4711_cors_errors_accessing_task_data_short';
 
+/**
+ * Allow the ability to filter annotations by their original created_at timestamp
+ */
+export const FF_LSDV_5035 = 'fflag_feat_back_lsdv_5035_use_created_at_from_draft_for_annotation_256052023_short';
+
 // Customize flags
 const flags = {};
 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
Uses the draft_created_at value as the createdDate to keep with a historical data that is consistent based on the work done. This is so the annotation tabs can be properly sorted.


#### What feature flags were used to cover this change?
`fflag_feat_back_lsdv_5035_use_created_at_from_draft_for_annotation_256052023_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Annotation, Draft

